### PR TITLE
Fixing deletion bug

### DIFF
--- a/main.c
+++ b/main.c
@@ -134,8 +134,12 @@ void deleteContact(int index) {
 // deletes first contact in list
 void deleteFirstContact() {
     struct contact_t* todelete = head;
-    head->next->prev = NULL;
-    head = head->next;
+    if(head->next != NULL) {
+        head->next->prev = NULL;
+        head = head->next;
+    } else {
+        head = NULL
+    }
     free(todelete);
 }
 


### PR DESCRIPTION
Fixing deletion bug when head is the only element left in the linked list. Since there is no next element, a segmentation error is thrown.
Solution is to check, if head->next is not null and if so simply set head to null.